### PR TITLE
Added max_length=2000 to URLField

### DIFF
--- a/embeds/models.py
+++ b/embeds/models.py
@@ -8,7 +8,7 @@ OEMBED_TYPES = (
 )
 
 class SavedEmbed(models.Model):
-    url = models.URLField()
+    url = models.URLField(max_length=2000)
     maxwidth = models.SmallIntegerField(null=True, blank=True)
     type = models.CharField(max_length=10, choices=OEMBED_TYPES)
     html = models.TextField(blank=True)


### PR DESCRIPTION
Django URLField defaults to a length of 200. 

MySQL, Postgres and SQLite have no limit on the max length of a varchar, and it sounds like a bigger length limit doesn't take any more space. IE7 and 8 have a max url length of 2038, so I think 2000 is enough.
